### PR TITLE
feat(missions): suit in corner, values centered on chips

### DIFF
--- a/src/components/MissionTarget.tsx
+++ b/src/components/MissionTarget.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Mission } from '../types/game';
 
 type Shape = {
-  kind: 'group' | 'seq';
+  kind: 'group' | 'seq' | 'free';
   count: number;
   cornerSuit?: string;
   cornerSuits?: string[];
@@ -17,6 +17,7 @@ const suitColor = (s: string) => (s.includes('♥') || s.includes('♦')) ? RED 
 function missionToShapes(mission: Mission): Shape[] {
   const G = (count: number, extra: Partial<Shape> = {}): Shape => ({ kind: 'group', count, ...extra });
   const S = (count: number, extra: Partial<Shape> = {}): Shape => ({ kind: 'seq', count, ...extra });
+  const F = (count: number, extra: Partial<Shape> = {}): Shape => ({ kind: 'free', count, ...extra });
 
   const reqs = mission.requirements;
   const minSeq = reqs.minSequenceLength ?? 3;
@@ -34,13 +35,13 @@ function missionToShapes(mission: Mission): Shape[] {
     case 'two_groups_3_one_group_4':
       return [G(3), G(3), G(4)];
     case '7_same_suit':
-      return [G(7)];
+      return [F(7, { values: Array(7).fill('?') })];
     case 'sequence_8_max_2_suits':
       return [S(8)];
     case 'sequence_A_to_9':
       return [S(9, { values: ['A', '2', '3', '4', '5', '6', '7', '8', '9'] })];
     case 'seven_odd_cards':
-      return [G(7, { values: ['A', '3', '5', '7', '9', 'J', 'K'] })];
+      return [F(7, { values: ['A', '3', '5', '7', '9', 'J', 'K'] })];
     case 'full_suit_A_to_K':
       return [S(13, { values: ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'] })];
     case 'hearts_7_8_9_10':
@@ -90,13 +91,16 @@ const MissionTarget: React.FC<Props> = ({ mission, compact = false }) => {
     <div style={{ display: 'flex', alignItems: 'flex-end', flexWrap: 'wrap', gap: groupGap }}>
       {shapes.map((shape, i) => {
         const isGroup = shape.kind === 'group';
+        const isFree = shape.kind === 'free';
         const arrowColor = isGroup ? '#b07c1a' : '#1f6a4e';
-        const chipBg = isGroup ? '#fde9b8' : '#c8ecdd';
-        const chipBorder = isGroup ? '#c09233' : '#2d8f6b';
+        const chipBg = isFree ? '#ece5d3' : isGroup ? '#fde9b8' : '#c8ecdd';
+        const chipBorder = isFree ? '#a89c7c' : isGroup ? '#c09233' : '#2d8f6b';
 
         return (
           <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            {isGroup ? (
+            {isFree ? (
+              <div style={{ height: arrowSize + 1, marginBottom: 3 }} />
+            ) : isGroup ? (
               <div style={{ display: 'flex', gap, marginBottom: 3 }}>
                 {Array.from({ length: shape.count }).map((_, j) => (
                   <div key={j} style={{

--- a/src/components/MissionTarget.tsx
+++ b/src/components/MissionTarget.tsx
@@ -34,7 +34,7 @@ function missionToShapes(mission: Mission): Shape[] {
     case 'two_groups_3_one_group_4':
       return [G(3), G(3), G(4)];
     case '7_same_suit':
-      return [G(7, { cornerSuit: '♠' })];
+      return [G(7)];
     case 'sequence_8_max_2_suits':
       return [S(8)];
     case 'sequence_A_to_9':
@@ -42,7 +42,7 @@ function missionToShapes(mission: Mission): Shape[] {
     case 'seven_odd_cards':
       return [G(7, { values: ['A', '3', '5', '7', '9', 'J', 'K'] })];
     case 'full_suit_A_to_K':
-      return [S(13, { cornerSuit: '♠', values: ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'] })];
+      return [S(13, { values: ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'] })];
     case 'hearts_7_8_9_10':
       return [S(4, { cornerSuit: '♥', values: ['7', '8', '9', '10'] })];
     case 'spades_and_clubs_sequences':
@@ -58,7 +58,7 @@ function missionToShapes(mission: Mission): Shape[] {
     case 'different_suits':
       return [S(5, { cornerSuit: '♠' }), S(5, { cornerSuit: '♥' })];
     case 'same_suit':
-      return [S(minSeq, { cornerSuit: '♥' })];
+      return [S(minSeq)];
   }
 
   // Generic: groups + sequences combos

--- a/src/components/MissionTarget.tsx
+++ b/src/components/MissionTarget.tsx
@@ -4,12 +4,15 @@ import { Mission } from '../types/game';
 type Shape = {
   kind: 'group' | 'seq';
   count: number;
-  constraint?: string;
-  constraintColor?: string;
+  cornerSuit?: string;
+  cornerSuits?: string[];
+  values?: string[];
 };
 
 const RED = '#c62b2b';
 const BLACK = '#1a1a1a';
+
+const suitColor = (s: string) => (s.includes('♥') || s.includes('♦')) ? RED : BLACK;
 
 function missionToShapes(mission: Mission): Shape[] {
   const G = (count: number, extra: Partial<Shape> = {}): Shape => ({ kind: 'group', count, ...extra });
@@ -21,7 +24,6 @@ function missionToShapes(mission: Mission): Shape[] {
   const sequences = reqs.sequences ?? 0;
   const spec = reqs.specificRequirements;
 
-  // Specific-requirement overrides — built from mission semantics.
   switch (spec) {
     case 'groups_of_4':
       return [G(4), G(4)];
@@ -32,31 +34,31 @@ function missionToShapes(mission: Mission): Shape[] {
     case 'two_groups_3_one_group_4':
       return [G(3), G(3), G(4)];
     case '7_same_suit':
-      return [G(7, { constraint: '♠', constraintColor: BLACK })];
+      return [G(7, { cornerSuit: '♠' })];
     case 'sequence_8_max_2_suits':
       return [S(8)];
     case 'sequence_A_to_9':
-      return [S(9)];
+      return [S(9, { values: ['A', '2', '3', '4', '5', '6', '7', '8', '9'] })];
     case 'seven_odd_cards':
-      return [G(7)];
+      return [G(7, { values: ['A', '3', '5', '7', '9', 'J', 'K'] })];
     case 'full_suit_A_to_K':
-      return [S(13, { constraint: '♠', constraintColor: BLACK })];
+      return [S(13, { cornerSuit: '♠', values: ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'] })];
     case 'hearts_7_8_9_10':
-      return [S(4, { constraint: '♥', constraintColor: RED })];
+      return [S(4, { cornerSuit: '♥', values: ['7', '8', '9', '10'] })];
     case 'spades_and_clubs_sequences':
-      return [S(4, { constraint: '♠', constraintColor: BLACK }), S(4, { constraint: '♣', constraintColor: BLACK })];
+      return [S(4, { cornerSuit: '♠' }), S(4, { cornerSuit: '♣' })];
     case 'red_sequence_5':
-      return [S(5, { constraint: '♥', constraintColor: RED })];
+      return [S(5, { cornerSuit: '♥/♦' })];
     case 'red_even_sequence_6':
-      return [S(6, { constraint: '♥', constraintColor: RED })];
+      return [S(6, { cornerSuit: '♥/♦', values: ['2', '4', '6', '8', '10', 'Q'] })];
     case 'one_red_group_one_black_group':
-      return [G(3, { constraint: '♥', constraintColor: RED }), G(3, { constraint: '♠', constraintColor: BLACK })];
+      return [G(3, { cornerSuit: '♥/♦' }), G(3, { cornerSuit: '♠/♣' })];
     case 'three_suits_no_diamonds':
-      return [G(3)];
+      return [G(3, { cornerSuits: ['♠', '♣', '♥'] })];
     case 'different_suits':
-      return [S(5, { constraint: '♠', constraintColor: BLACK }), S(5, { constraint: '♥', constraintColor: RED })];
+      return [S(5, { cornerSuit: '♠' }), S(5, { cornerSuit: '♥' })];
     case 'same_suit':
-      return [S(minSeq, { constraint: '♥', constraintColor: RED })];
+      return [S(minSeq, { cornerSuit: '♥' })];
   }
 
   // Generic: groups + sequences combos
@@ -76,11 +78,13 @@ const MissionTarget: React.FC<Props> = ({ mission, compact = false }) => {
   const shapes = missionToShapes(mission);
   if (!shapes.length) return null;
 
-  const chipW = compact ? 18 : 24;
-  const chipH = compact ? 26 : 34;
+  const chipW = compact ? 20 : 26;
+  const chipH = compact ? 28 : 36;
   const gap = compact ? 3 : 4;
   const groupGap = compact ? 12 : 18;
   const arrowSize = compact ? 12 : 15;
+  const cornerFs = compact ? 8 : 9;
+  const valueFs = compact ? 11 : 13;
 
   return (
     <div style={{ display: 'flex', alignItems: 'flex-end', flexWrap: 'wrap', gap: groupGap }}>
@@ -89,7 +93,6 @@ const MissionTarget: React.FC<Props> = ({ mission, compact = false }) => {
         const arrowColor = isGroup ? '#b07c1a' : '#1f6a4e';
         const chipBg = isGroup ? '#fde9b8' : '#c8ecdd';
         const chipBorder = isGroup ? '#c09233' : '#2d8f6b';
-        const constraintColor = shape.constraintColor || (isGroup ? '#7a5410' : '#1f6a4e');
 
         return (
           <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
@@ -119,21 +122,38 @@ const MissionTarget: React.FC<Props> = ({ mission, compact = false }) => {
               </div>
             )}
             <div style={{ display: 'flex', gap }}>
-              {Array.from({ length: shape.count }).map((_, j) => (
-                <div key={j} style={{
-                  width: chipW, height: chipH, borderRadius: 3,
-                  background: chipBg,
-                  border: `1px solid ${chipBorder}`,
-                  boxShadow: 'inset 0 -2px 0 rgba(0,0,0,0.08)',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  fontSize: Math.min(chipW - 6, chipH - 12),
-                  color: constraintColor,
-                  fontWeight: 700, lineHeight: 1,
-                  fontFamily: 'Georgia, serif',
-                }}>
-                  {shape.constraint || ''}
-                </div>
-              ))}
+              {Array.from({ length: shape.count }).map((_, j) => {
+                const corner = shape.cornerSuits?.[j] ?? shape.cornerSuit;
+                const value = shape.values?.[j];
+                return (
+                  <div key={j} style={{
+                    width: chipW, height: chipH, borderRadius: 3,
+                    background: chipBg,
+                    border: `1px solid ${chipBorder}`,
+                    boxShadow: 'inset 0 -2px 0 rgba(0,0,0,0.08)',
+                    position: 'relative',
+                    fontFamily: 'Georgia, serif',
+                  }}>
+                    {corner && (
+                      <div style={{
+                        position: 'absolute', top: 1, left: 2,
+                        fontSize: cornerFs, lineHeight: 1,
+                        color: suitColor(corner),
+                        fontWeight: 700, whiteSpace: 'nowrap',
+                      }}>{corner}</div>
+                    )}
+                    {value && (
+                      <div style={{
+                        position: 'absolute', left: 0, right: 0, bottom: 0,
+                        top: corner ? cornerFs + 2 : 0,
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        fontSize: valueFs, fontWeight: 800,
+                        color: BLACK, lineHeight: 1,
+                      }}>{value}</div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
         );


### PR DESCRIPTION
## Summary
- Mission chips now place the suit constraint in the top-left corner and the value constraint (when applicable) centered on the chip
- Color-only missions render as paired suits (`♥/♦`, `♠/♣`) in the corner instead of a single suit, keeping placement consistent
- Per-card suit override (`cornerSuits`) supports the "three suits, no diamonds" mission
- New `free` shape kind for missions where cards aren't a group nor a sequence (no connector arrow, neutral chip color) — used for missions 7 and 20

## Screenshots

**Mission 25 — Suite 7-8-9-10 de cœur** (sorte + valeurs)
![mission 25](https://raw.githubusercontent.com/klbsjpolp/cirque-rummy/screenshots/pr-14/mission_25.png)

**Mission 30 — Suite paire 6 cartes rouges** (couleur ♥/♦ + valeurs)
![mission 30](https://raw.githubusercontent.com/klbsjpolp/cirque-rummy/screenshots/pr-14/mission_30.png)

**Mission 24 — Suite complète A→K d'une couleur** (suite, sorte libre mais uniforme)
![mission 24](https://raw.githubusercontent.com/klbsjpolp/cirque-rummy/screenshots/pr-14/mission_24.png)

**Mission 28 — Deux groupes : un rouge, un noir** (♥/♦ + ♠/♣)
![mission 28](https://raw.githubusercontent.com/klbsjpolp/cirque-rummy/screenshots/pr-14/mission_28.png)

**Mission 27 — Suite de 5 cartes rouges** (couleur seule ♥/♦)
![mission 27](https://raw.githubusercontent.com/klbsjpolp/cirque-rummy/screenshots/pr-14/mission_27.png)

**Mission 7 — 7 cartes même couleur** (free, pas de flèche)
![mission 7](https://raw.githubusercontent.com/klbsjpolp/cirque-rummy/screenshots/pr-14/mission_7.png)

**Mission 20 — Sept cartes impaires** (free + valeurs imposées)
![mission 20](https://raw.githubusercontent.com/klbsjpolp/cirque-rummy/screenshots/pr-14/mission_20.png)

## Test plan
- [x] Mission 25 (♥ + 7-8-9-10)
- [x] Mission 30 (♥/♦ + 2-4-6-8-10-Q)
- [x] Mission 24 (no suit icon, A→K values)
- [x] Mission 28 (♥/♦ and ♠/♣ groups)
- [x] Mission 27 (♥/♦ only, no values)
- [x] Mission 7 (free kind, ? placeholders)
- [x] Mission 20 (free kind, odd values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)