### PR TITLE
refactor(game-logic): extract pure mission logic and add unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.5.0
         version: 3.11.0(vite@6.3.4(@types/node@22.19.17)(jiti@1.21.7))
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -226,6 +229,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -233,13 +240,30 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@commitlint/cli@20.5.3':
     resolution: {integrity: sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==}
@@ -588,6 +612,14 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -612,6 +644,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1644,6 +1680,15 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1702,9 +1747,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1729,6 +1782,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   autoprefixer@10.5.0:
     resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
@@ -1755,6 +1811,9 @@ packages:
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1965,6 +2024,9 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
@@ -1983,6 +2045,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -2139,6 +2204,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -2171,6 +2240,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
     engines: {node: '>=20'}
@@ -2194,6 +2268,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -2286,6 +2363,25 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -2293,6 +2389,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2370,6 +2469,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
@@ -2389,8 +2495,16 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -2446,6 +2560,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2467,6 +2584,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2713,6 +2834,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -2737,9 +2862,17 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2776,6 +2909,10 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -3025,6 +3162,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -3067,6 +3208,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -3081,9 +3227,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@commitlint/cli@20.5.3(@types/node@22.19.17)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
@@ -3385,6 +3544,17 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3410,6 +3580,9 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -4412,6 +4585,25 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@22.19.17)(@vitest/ui@3.2.4)(jiti@1.21.7)(jsdom@26.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -4489,9 +4681,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -4511,6 +4707,12 @@ snapshots:
   array-ify@1.0.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   autoprefixer@10.5.0(postcss@8.5.13):
     dependencies:
@@ -4533,6 +4735,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -4736,6 +4942,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.349: {}
 
   embla-carousel-react@8.6.0(react@18.3.1):
@@ -4751,6 +4959,8 @@ snapshots:
   embla-carousel@8.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   entities@6.0.1: {}
 
@@ -4933,6 +5143,11 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fraction.js@5.3.4: {}
 
   fsevents@2.3.3:
@@ -4960,6 +5175,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   global-directory@5.0.0:
     dependencies:
       ini: 6.0.0
@@ -4977,6 +5201,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -5048,9 +5274,38 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5134,6 +5389,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   meow@13.2.0: {}
 
   merge2@1.4.1: {}
@@ -5151,7 +5416,13 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mrmime@2.0.1: {}
 
@@ -5199,6 +5470,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5219,6 +5492,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -5459,6 +5737,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -5482,9 +5762,19 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@3.1.1: {}
 
@@ -5543,6 +5833,12 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   thenify-all@1.6.0:
     dependencies:
@@ -5785,6 +6081,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   ws@8.20.0: {}
 

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,26 +1,27 @@
 
 import { useState, useEffect } from 'react';
-import {GameState, Player, Card, Combination, NormalCard} from '../types/game';
+import {GameState, Player, Card, Combination} from '../types/game';
 import {
   createDeck,
   isValidGroup,
   isValidSequence,
   isJokerCard,
-  isNormalCard,
   validateMissionFromSelection,
-  findAllValidCombinations
+  findAllValidCombinations,
+  getSuitSymbol
 } from '../utils/cardUtils';
 import { MISSIONS } from '../data/missions';
 import { AIPlayer } from '../utils/aiPlayer';
+import {
+  canAddToExistingCombination,
+  isMissionCompleted,
+  pickRandomMissionId
+} from '../utils/gameLogic';
 
 const STORAGE_KEY = 'cirque-rummy-game-state';
 
-const getRandomMission = (completedMissions: number[]): number => {
-  const availableMissions = MISSIONS.filter(mission => !completedMissions.includes(mission.id));
-  if (availableMissions.length === 0) return 1; // Fallback, should not happen
-  const randomIndex = Math.floor(Math.random() * availableMissions.length);
-  return availableMissions[randomIndex].id;
-};
+const getRandomMission = (completedMissions: number[]): number =>
+  pickRandomMissionId(MISSIONS, completedMissions);
 
 const createPlayer = (id: string, name: string): Player => ({
   id,
@@ -412,31 +413,6 @@ export const useGameState = () => {
     });
   };
 
-  // Helper function to check if cards can be added to an existing combination
-  const canAddToExistingCombination = (cardsToAdd: Card[], combination: Combination): boolean => {
-    // For groups: check if all cards have the same value as the group
-    if (combination.type === 'group') {
-      const existingValue = combination.cards.find(c => isNormalCard(c))?.value;
-      if (!existingValue) return false;
-
-      return cardsToAdd.every(card => {
-        if (isJokerCard(card)) return true; // Jokers can be added to any group
-        return isNormalCard(card) && card.value === existingValue;
-      });
-    }
-
-    // For sequences: check if cards can extend the sequence
-    if (combination.type === 'sequence') {
-      // This is a simplified check - you might want to implement more sophisticated logic
-      // to check if the cards can extend the sequence at either end
-      const combinedCards = [...combination.cards, ...cardsToAdd];
-      return isValidSequence(combinedCards);
-    }
-
-    return false;
-  };
-
-
   const addToExistingCombination = (cardIds: string[], combinationId: string, targetPlayerId?: string) => {
     const currentPlayer = gameState.players[gameState.currentPlayerIndex];
 
@@ -541,161 +517,7 @@ export const useGameState = () => {
     const mission = MISSIONS.find(m => m.id === player.currentMission);
     if (!mission) return;
 
-    const { requirements } = mission;
-    const { combinations } = player;
-
-    let isCompleted = false;
-
-    // Helper functions
-    const getAllCards = () => combinations.flatMap(c => c.cards);
-    const getGroups = () => combinations.filter(c => c.type === 'group');
-    const getSequences = () => combinations.filter(c => c.type === 'sequence');
-    const isRedCard = (card: NormalCard) => card.suit === 'hearts' || card.suit === 'diamonds';
-    const isBlackCard = (card: NormalCard) => card.suit === 'spades' || card.suit === 'clubs';
-
-    if (requirements.specificRequirements === 'free_choice') {
-      // Mission 12: choose a previously completed mission
-      isCompleted = player.completedMissions.length > 0;
-    } else if (requirements.specificRequirements === '7_same_suit') {
-      // Mission 7: 7 cards of same suit
-      const suitCounts = combinations.reduce((acc, combo) => {
-        combo.cards.forEach(card => {
-          if (isNormalCard(card)) {
-            acc[card.suit] = (acc[card.suit] || 0) + 1;
-          }
-        });
-        return acc;
-      }, {} as Record<string, number>);
-
-      isCompleted = Object.values(suitCounts).some(count => count >= 7);
-    } else if (requirements.specificRequirements === 'group_4_sequence_4') {
-      // Mission 13: One group of 4 + one sequence of 4
-      const groups = getGroups();
-      const sequences = getSequences();
-      isCompleted = groups.some(g => g.cards.length === 4) && sequences.some(s => s.cards.length >= 4);
-    } else if (requirements.specificRequirements === 'groups_of_4') {
-      // Mission 14: Two groups of 4
-      const groups = getGroups();
-      const groupsOf4 = groups.filter(g => g.cards.length === 4);
-      isCompleted = groupsOf4.length >= 2;
-    } else if (requirements.specificRequirements === 'sequence_8_max_2_suits') {
-      // Mission 16: Sequence of 8 with max 2 suits
-      const sequences = getSequences();
-      isCompleted = sequences.some(seq => {
-        if (seq.cards.length < 8) return false;
-        const suits = new Set(seq.cards.filter(c => isNormalCard(c)).map(c => c.suit));
-        return suits.size <= 2;
-      });
-    } else if (requirements.specificRequirements === 'two_groups_3_one_group_4') {
-      // Mission 17: Two groups of 3 + one group of 4
-      const groups = getGroups();
-      const groupsOf3 = groups.filter(g => g.cards.length === 3);
-      const groupsOf4 = groups.filter(g => g.cards.length === 4);
-      isCompleted = groupsOf3.length >= 2 && groupsOf4.length >= 1;
-    } else if (requirements.specificRequirements === 'sequence_A_to_9') {
-      // Mission 19: Sequence A to 9 (any suits)
-      const allCards = getAllCards().filter(c => isNormalCard(c));
-      const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9'];
-      const hasAllValues = values.every(val => allCards.some(card => card.value === val));
-      isCompleted = hasAllValues && allCards.length >= 9;
-    } else if (requirements.specificRequirements === 'seven_odd_cards') {
-      // Mission 20: Seven odd cards (A, 3, 5, 7, 9, J, K)
-      const allCards = getAllCards().filter(c => isNormalCard(c));
-      const oddValues = ['A', '3', '5', '7', '9', 'J', 'K'];
-      const oddCards = allCards.filter(card => oddValues.includes(card.value));
-      isCompleted = oddCards.length >= 7;
-    } else if (requirements.specificRequirements === 'different_suits') {
-      // Mission 21: Two sequences of 5, different suits
-      const sequences = getSequences().filter(s => s.cards.length >= 5);
-      if (sequences.length >= 2) {
-        const suits1 = new Set(sequences[0].cards.filter(c => isNormalCard(c)).map(c => c.suit));
-        const suits2 = new Set(sequences[1].cards.filter(c => isNormalCard(c)).map(c => c.suit));
-        const intersection = new Set([...suits1].filter(x => suits2.has(x)));
-        isCompleted = intersection.size === 0;
-      }
-    } else if (requirements.specificRequirements === 'pairs') {
-      // Mission 22: 4 groups of 2 cards (pairs)
-      const groups = getGroups();
-      const pairs = groups.filter(g => g.cards.length === 2);
-      isCompleted = pairs.length >= 4;
-    } else if (requirements.specificRequirements === 'three_groups_of_4') {
-      // Mission 23: Three groups of 4
-      const groups = getGroups();
-      const groupsOf4 = groups.filter(g => g.cards.length === 4);
-      isCompleted = groupsOf4.length >= 3;
-    } else if (requirements.specificRequirements === 'full_suit_A_to_K') {
-      // Mission 24: Full suit A to K
-      const sequences = getSequences();
-      isCompleted = sequences.some(seq => {
-        if (seq.cards.length < 13) return false;
-        const nonJokerCards = seq.cards.filter(c => isNormalCard(c));
-        const suits = new Set(nonJokerCards.map(c => c.suit));
-        return suits.size === 1;
-      });
-    } else if (requirements.specificRequirements === 'hearts_7_8_9_10') {
-      // Mission 25: 7-8-9-10 of hearts
-      const allCards = getAllCards().filter(c => isNormalCard(c));
-      const heartsCards = allCards.filter(c => c.suit === 'hearts');
-      const requiredValues = ['7', '8', '9', '10'];
-      isCompleted = requiredValues.every(val => heartsCards.some(card => card.value === val));
-    } else if (requirements.specificRequirements === 'spades_and_clubs_sequences') {
-      // Mission 26: Two sequences of 4: one spades, one clubs
-      const sequences = getSequences().filter(s => s.cards.length >= 4);
-      const spadesSeq = sequences.find(s => s.cards.filter(c => isNormalCard(c)).every(c => c.suit === 'spades'));
-      const clubsSeq = sequences.find(s => s.cards.filter(c => isNormalCard(c)).every(c => c.suit === 'clubs'));
-      isCompleted = !!spadesSeq && !!clubsSeq;
-    } else if (requirements.specificRequirements === 'red_sequence_5') {
-      // Mission 27: Sequence of 5 red cards
-      const sequences = getSequences();
-      isCompleted = sequences.some(seq => {
-        if (seq.cards.length < 5) return false;
-        const nonJokerCards = seq.cards.filter(c => isNormalCard(c));
-        return nonJokerCards.length >= 5 && nonJokerCards.every(c => isRedCard(c));
-      });
-    } else if (requirements.specificRequirements === 'one_red_group_one_black_group') {
-      // Mission 28: Two groups of 3: one red, one black
-      const groups = getGroups().filter(g => g.cards.length >= 3);
-      const redGroup = groups.find(g => g.cards.filter(c => isNormalCard(c)).every(c => isRedCard(c)));
-      const blackGroup = groups.find(g => g.cards.filter(c => isNormalCard(c)).every(c => isBlackCard(c)));
-      isCompleted = !!redGroup && !!blackGroup;
-    } else if (requirements.specificRequirements === 'three_suits_no_diamonds') {
-      // Mission 29: Three identical cards (spades, clubs, hearts only)
-      const groups = getGroups();
-      isCompleted = groups.some(g => {
-        if (g.cards.length < 3) return false;
-        const nonJokerCards = g.cards.filter(c => isNormalCard(c));
-        const suits = new Set(nonJokerCards.map(c => c.suit));
-        return suits.has('spades') && suits.has('clubs') && suits.has('hearts') && !suits.has('diamonds');
-      });
-    } else if (requirements.specificRequirements === 'red_even_sequence_6') {
-      // Mission 30: Even sequence of 6 red cards (2,4,6,8,10,Q)
-      const allCards = getAllCards().filter(isNormalCard).filter(isRedCard);
-      const evenValues = ['2', '4', '6', '8', '10', 'Q'];
-      isCompleted = evenValues.every(val => allCards.some(card => card.value === val));
-    } else {
-      // Standard missions
-      const groups = getGroups();
-      const sequences = getSequences();
-
-      const hasRequiredGroups = !requirements.groups || groups.length >= requirements.groups;
-      const hasRequiredSequences = !requirements.sequences || sequences.length >= requirements.sequences;
-
-      let hasMinSequenceLength = true;
-      if (requirements.minSequenceLength) {
-        hasMinSequenceLength = sequences.some(seq => seq.cards.length >= requirements.minSequenceLength!);
-      }
-
-      let hasSameSuitRequirement = true;
-      if (requirements.specificRequirements === 'same_suit') {
-        hasSameSuitRequirement = sequences.some(seq => {
-          const nonJokerCards = seq.cards.filter(c => isNormalCard(c));
-          return nonJokerCards.length >= (requirements.minSequenceLength || 3) &&
-                 nonJokerCards.every(c => c.suit === nonJokerCards[0].suit);
-        });
-      }
-
-      isCompleted = hasRequiredGroups && hasRequiredSequences && hasMinSequenceLength && hasSameSuitRequirement;
-    }
+    const isCompleted = isMissionCompleted(player, mission);
 
     if (isCompleted) {
       player.completedMissions.push(player.currentMission);
@@ -805,15 +627,4 @@ export const useGameState = () => {
     resetGame,
     reorderCards
   };
-};
-
-// Helper function (need to import from cardUtils)
-const getSuitSymbol = (suit: string): string => {
-  switch (suit) {
-    case 'hearts': return '♥';
-    case 'diamonds': return '♦';
-    case 'clubs': return '♣';
-    case 'spades': return '♠';
-    default: return '';
-  }
 };

--- a/src/tests/aiPlayer.test.ts
+++ b/src/tests/aiPlayer.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AIPlayer } from '../utils/aiPlayer';
+import { Card, GameState, Player } from '../types/game';
+import { createCard, createJokerCard } from './testUtils';
+import { isJokerCard, isNormalCard } from '../utils/cardUtils';
+
+const createPlayer = (id: string, name: string, hand: Card[] = []): Player => ({
+  id,
+  name,
+  hand,
+  currentMission: 1,
+  completedMissions: [],
+  score: 0,
+  combinations: [],
+  isCurrentMissionCompleted() {
+    return this.completedMissions.includes(this.currentMission);
+  },
+});
+
+const createGameState = (players: Player[], deck: Card[], discardPile: Card[] = []): GameState => ({
+  players,
+  currentPlayerIndex: 1, // AI is player index 1 by default
+  deck,
+  discardPile,
+  isGameStarted: true,
+  isGameOver: false,
+  winner: null,
+  gameHistory: [],
+  gameMode: 'ai',
+  isAITurn: true,
+  cardsDrawnThisTurn: 0,
+  hasDrawnThisTurn: false,
+  mustDiscardToEndTurn: false,
+  lastDrawnCardId: null,
+});
+
+describe('AIPlayer', () => {
+  beforeEach(() => {
+    // Make Math.random deterministic: always return 0 (first index)
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('makeMove - normal turn', () => {
+    it('draws one card from the deck and discards one card', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [createCard('5', 'spades'), createCard('7', 'clubs')]);
+      const deck = [createCard('K', 'diamonds'), createCard('Q', 'hearts')];
+      const state = createGameState([human, ai], deck);
+
+      const initialHandSize = ai.hand.length;
+      const initialDeckSize = state.deck.length;
+      const initialDiscardSize = state.discardPile.length;
+
+      AIPlayer.makeMove(state);
+
+      // AI hand size should be unchanged (drew 1, discarded 1)
+      expect(ai.hand).toHaveLength(initialHandSize);
+      // Deck shrinks by 1
+      expect(state.deck).toHaveLength(initialDeckSize - 1);
+      // Discard pile grows by 1
+      expect(state.discardPile).toHaveLength(initialDiscardSize + 1);
+    });
+
+    it('records draw and discard in game history', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [createCard('5', 'spades')]);
+      const deck = [createCard('K', 'diamonds'), createCard('Q', 'hearts')];
+      const state = createGameState([human, ai], deck);
+
+      AIPlayer.makeMove(state);
+
+      expect(state.gameHistory.some(h => h.includes('AI') && h.includes('pioche'))).toBe(true);
+      expect(state.gameHistory.some(h => h.includes('AI') && h.includes('défausse'))).toBe(true);
+    });
+
+    it('advances currentPlayerIndex to next player when round did not end', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [createCard('5', 'spades'), createCard('7', 'clubs')]);
+      const deck = [createCard('K', 'diamonds')];
+      const state = createGameState([human, ai], deck);
+      state.currentPlayerIndex = 1;
+
+      AIPlayer.makeMove(state);
+
+      expect(state.currentPlayerIndex).toBe(0);
+    });
+
+    it('draws the top card of the deck (last element)', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [createCard('5', 'spades')]);
+      const topCard = createCard('K', 'diamonds');
+      const deck = [createCard('2', 'clubs'), topCard];
+      const state = createGameState([human, ai], deck);
+
+      AIPlayer.makeMove(state);
+
+      // Top card should now be in AI's hand or in the discard pile
+      // (since Math.random=0 picks the first card in hand to discard, and the new card was pushed last,
+      // the original first card is discarded and the drawn card stays in the hand)
+      const drawnCardInHand = ai.hand.some(c => c.id === topCard.id);
+      const drawnCardInDiscard = state.discardPile.some(c => c.id === topCard.id);
+      expect(drawnCardInHand || drawnCardInDiscard).toBe(true);
+    });
+
+    it('formats discard message with card value for normal cards', () => {
+      const human = createPlayer('p1', 'Human', []);
+      const ai = createPlayer('ai', 'AI', [createCard('7', 'clubs')]);
+      const deck = [createCard('K', 'diamonds'), createCard('Q', 'hearts')];
+      const state = createGameState([human, ai], deck);
+
+      AIPlayer.makeMove(state);
+
+      const discardMsg = state.gameHistory.find(h => h.includes('défausse'));
+      expect(discardMsg).toBeDefined();
+      // With Math.random=0, the first card in hand (the 7 of clubs) is discarded
+      expect(discardMsg).toContain('7');
+    });
+
+    it('formats discard message as "Joker" when discarding a joker', () => {
+      const human = createPlayer('p1', 'Human', []);
+      const joker = createJokerCard();
+      const ai = createPlayer('ai', 'AI', [joker]);
+      const deck = [createCard('K', 'diamonds'), createCard('Q', 'hearts')];
+      const state = createGameState([human, ai], deck);
+
+      AIPlayer.makeMove(state);
+
+      const discardMsg = state.gameHistory.find(h => h.includes('défausse'));
+      expect(discardMsg).toContain('Joker');
+    });
+  });
+
+  describe('makeMove - empty deck', () => {
+    it('does not crash when the deck is empty and still discards', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [createCard('5', 'spades'), createCard('7', 'clubs')]);
+      const state = createGameState([human, ai], []);
+
+      const initialHandSize = ai.hand.length;
+      const initialDiscardSize = state.discardPile.length;
+
+      expect(() => AIPlayer.makeMove(state)).not.toThrow();
+      // No draw possible, but discard still happens
+      expect(ai.hand).toHaveLength(initialHandSize - 1);
+      expect(state.discardPile).toHaveLength(initialDiscardSize + 1);
+    });
+
+    it('does nothing when both deck and hand are empty', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', []);
+      const state = createGameState([human, ai], []);
+
+      const startIdx = state.currentPlayerIndex;
+      expect(() => AIPlayer.makeMove(state)).not.toThrow();
+      expect(ai.hand).toHaveLength(0);
+      expect(state.discardPile).toHaveLength(0);
+      // currentPlayerIndex should not change since the discard branch never ran
+      expect(state.currentPlayerIndex).toBe(startIdx);
+    });
+  });
+
+  describe('makeMove - round end', () => {
+    it('triggers round end and redistributes 13 cards when AI goes out', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      // AI has empty hand to start; deck has 1 card so it draws then discards, ending with 0
+      const ai = createPlayer('ai', 'AI', []);
+      const drawCard = createCard('5', 'spades');
+      const state = createGameState([human, ai], [drawCard]);
+
+      AIPlayer.makeMove(state);
+
+      // After round end:
+      // - both players should have 13 cards
+      expect(human.hand).toHaveLength(13);
+      expect(ai.hand).toHaveLength(13);
+      // - combinations cleared
+      expect(human.combinations).toEqual([]);
+      expect(ai.combinations).toEqual([]);
+      // - new discard pile has 1 card
+      expect(state.discardPile).toHaveLength(1);
+      // - currentPlayerIndex reset to 0
+      expect(state.currentPlayerIndex).toBe(0);
+      // - isAITurn cleared
+      expect(state.isAITurn).toBe(false);
+      // - history mentions round end
+      expect(state.gameHistory.some(h => h.includes('termine la manche'))).toBe(true);
+      expect(state.gameHistory.some(h => h.includes('Nouvelle manche'))).toBe(true);
+    });
+
+    it('does not trigger round end when AI still has cards after discard', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [
+        createCard('5', 'spades'),
+        createCard('7', 'clubs'),
+        createCard('9', 'diamonds'),
+      ]);
+      const deck = [createCard('K', 'diamonds')];
+      const state = createGameState([human, ai], deck);
+
+      AIPlayer.makeMove(state);
+
+      expect(ai.hand.length).toBe(3); // drew 1, discarded 1, net 0
+      expect(state.gameHistory.some(h => h.includes('Nouvelle manche'))).toBe(false);
+    });
+
+    it('clears existing combinations from all players on round end', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      human.combinations = [
+        {
+          id: 'c1',
+          type: 'group',
+          cards: [createCard('3', 'hearts'), createCard('3', 'clubs'), createCard('3', 'spades')],
+        },
+      ];
+      const ai = createPlayer('ai', 'AI', []);
+      ai.combinations = [
+        {
+          id: 'c2',
+          type: 'group',
+          cards: [createCard('K', 'hearts'), createCard('K', 'clubs'), createCard('K', 'spades')],
+        },
+      ];
+      const state = createGameState([human, ai], [createCard('5', 'spades')]);
+
+      AIPlayer.makeMove(state);
+
+      expect(human.combinations).toEqual([]);
+      expect(ai.combinations).toEqual([]);
+    });
+  });
+
+  describe('makeMove with playable combinations in hand', () => {
+    it('still draws and discards even when valid groups are present', () => {
+      // Hand contains a valid group of 3 (three different-suit 7s) and a valid sequence
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [
+        createCard('7', 'clubs'),
+        createCard('7', 'diamonds'),
+        createCard('7', 'spades'),
+        createCard('4', 'hearts'),
+        createCard('5', 'hearts'),
+        createCard('6', 'hearts'),
+      ]);
+      const deck = [createCard('K', 'diamonds')];
+      const state = createGameState([human, ai], deck);
+
+      const initialHandSize = ai.hand.length;
+      AIPlayer.makeMove(state);
+
+      // Current AI implementation draws and discards regardless of available combinations
+      expect(ai.hand).toHaveLength(initialHandSize); // drew 1, discarded 1
+      expect(state.deck).toHaveLength(0);
+      expect(state.discardPile).toHaveLength(1);
+    });
+  });
+
+  describe('makeMove preserves total card invariant on normal turn', () => {
+    it('total card count stays constant after a draw+discard turn', () => {
+      const human = createPlayer('p1', 'Human', [createCard('A', 'hearts'), createCard('2', 'hearts')]);
+      const ai = createPlayer('ai', 'AI', [createCard('5', 'spades'), createCard('7', 'clubs')]);
+      const deck = [createCard('K', 'diamonds'), createCard('Q', 'hearts'), createCard('J', 'clubs')];
+      const initialDiscard = [createCard('3', 'diamonds')];
+      const state = createGameState([human, ai], deck, initialDiscard);
+
+      const totalBefore = human.hand.length + ai.hand.length + state.deck.length + state.discardPile.length;
+      AIPlayer.makeMove(state);
+      const totalAfter = human.hand.length + ai.hand.length + state.deck.length + state.discardPile.length;
+
+      expect(totalAfter).toBe(totalBefore);
+    });
+  });
+});

--- a/src/tests/gameLogic.test.ts
+++ b/src/tests/gameLogic.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canAddToExistingCombination,
+  isMissionCompleted,
+  pickRandomMissionId,
+} from '../utils/gameLogic';
+import { Card, Combination, Mission, Player } from '../types/game';
+import { createCard, createJokerCard } from './testUtils';
+import { MISSIONS } from '../data/missions';
+
+const mkCombination = (
+  type: 'group' | 'sequence',
+  cards: Card[],
+  id = `combo-${Math.random()}`
+): Combination => ({ id, type, cards });
+
+const mkPlayer = (
+  combinations: Combination[],
+  completedMissions: number[] = [],
+  currentMission = 1
+): Pick<Player, 'combinations' | 'completedMissions' | 'currentMission'> => ({
+  combinations,
+  completedMissions,
+  currentMission,
+});
+
+const findMission = (id: number): Mission => {
+  const m = MISSIONS.find(x => x.id === id);
+  if (!m) throw new Error(`Mission ${id} not found in fixtures`);
+  return m;
+};
+
+describe('canAddToExistingCombination', () => {
+  it('accepts adding a fourth distinct-suit card to a group of 3', () => {
+    const combo = mkCombination('group', [
+      createCard('7', 'clubs'),
+      createCard('7', 'diamonds'),
+      createCard('7', 'spades'),
+    ]);
+    expect(canAddToExistingCombination([createCard('7', 'hearts')], combo)).toBe(true);
+  });
+
+  it('rejects adding a card whose suit is already in the group (regression)', () => {
+    // Two 7-of-clubs cards exist in the deck (two decks, distinct ids).
+    // The old implementation only checked values matched, allowing this invalid add.
+    const combo = mkCombination('group', [
+      { id: '7-clubs-A', value: '7', suit: 'clubs' },
+      createCard('7', 'diamonds'),
+      createCard('7', 'spades'),
+    ]);
+    const duplicateSuit: Card = { id: '7-clubs-B', value: '7', suit: 'clubs' };
+    expect(canAddToExistingCombination([duplicateSuit], combo)).toBe(false);
+  });
+
+  it('rejects adding a card with a different value to a group', () => {
+    const combo = mkCombination('group', [
+      createCard('7', 'clubs'),
+      createCard('7', 'diamonds'),
+      createCard('7', 'spades'),
+    ]);
+    expect(canAddToExistingCombination([createCard('8', 'hearts')], combo)).toBe(false);
+  });
+
+  it('accepts a joker added to a group', () => {
+    const combo = mkCombination('group', [
+      createCard('7', 'clubs'),
+      createCard('7', 'diamonds'),
+      createCard('7', 'spades'),
+    ]);
+    expect(canAddToExistingCombination([createJokerCard()], combo)).toBe(true);
+  });
+
+  it('accepts a card extending a sequence', () => {
+    const combo = mkCombination('sequence', [
+      createCard('4', 'spades'),
+      createCard('5', 'spades'),
+      createCard('6', 'spades'),
+    ]);
+    expect(canAddToExistingCombination([createCard('7', 'spades')], combo)).toBe(true);
+    expect(canAddToExistingCombination([createCard('3', 'spades')], combo)).toBe(true);
+  });
+
+  it('rejects a card with wrong suit on a sequence', () => {
+    const combo = mkCombination('sequence', [
+      createCard('4', 'spades'),
+      createCard('5', 'spades'),
+      createCard('6', 'spades'),
+    ]);
+    expect(canAddToExistingCombination([createCard('7', 'hearts')], combo)).toBe(false);
+  });
+
+  it('rejects a non-consecutive card on a sequence', () => {
+    const combo = mkCombination('sequence', [
+      createCard('4', 'spades'),
+      createCard('5', 'spades'),
+      createCard('6', 'spades'),
+    ]);
+    expect(canAddToExistingCombination([createCard('K', 'spades')], combo)).toBe(false);
+  });
+});
+
+describe('pickRandomMissionId', () => {
+  const fixtures: Mission[] = [
+    { id: 1, title: 'a', description: '', icon: '', requirements: {} },
+    { id: 2, title: 'b', description: '', icon: '', requirements: {} },
+    { id: 3, title: 'c', description: '', icon: '', requirements: {} },
+  ];
+
+  it('picks the first available mission when rng returns 0', () => {
+    expect(pickRandomMissionId(fixtures, [], () => 0)).toBe(1);
+  });
+
+  it('skips already-completed missions', () => {
+    expect(pickRandomMissionId(fixtures, [1], () => 0)).toBe(2);
+    expect(pickRandomMissionId(fixtures, [1, 2], () => 0)).toBe(3);
+  });
+
+  it('selects deterministically based on rng', () => {
+    // 3 missions, rng=0.5 -> floor(1.5)=1 -> index 1 -> id 2
+    expect(pickRandomMissionId(fixtures, [], () => 0.5)).toBe(2);
+    // rng=0.99 -> floor(2.97)=2 -> index 2 -> id 3
+    expect(pickRandomMissionId(fixtures, [], () => 0.99)).toBe(3);
+  });
+
+  it('falls back to first mission id when nothing is available', () => {
+    expect(pickRandomMissionId(fixtures, [1, 2, 3], () => 0)).toBe(1);
+  });
+});
+
+describe('isMissionCompleted', () => {
+  describe('Mission 1 — two groups of 3 (standard)', () => {
+    const mission = findMission(1);
+
+    it('returns true with two valid groups', () => {
+      const player = mkPlayer([
+        mkCombination('group', [createCard('7', 'clubs'), createCard('7', 'diamonds'), createCard('7', 'spades')]),
+        mkCombination('group', [createCard('K', 'clubs'), createCard('K', 'diamonds'), createCard('K', 'spades')]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('returns false with only one group', () => {
+      const player = mkPlayer([
+        mkCombination('group', [createCard('7', 'clubs'), createCard('7', 'diamonds'), createCard('7', 'spades')]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 2 — sequence of 4 + group of 3 (minSequenceLength)', () => {
+    const mission = findMission(2);
+
+    it('returns true with seq>=4 and 1 group', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('4', 'spades'),
+          createCard('5', 'spades'),
+          createCard('6', 'spades'),
+          createCard('7', 'spades'),
+        ]),
+        mkCombination('group', [createCard('K', 'clubs'), createCard('K', 'diamonds'), createCard('K', 'spades')]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('returns false when sequence is only length 3', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('4', 'spades'),
+          createCard('5', 'spades'),
+          createCard('6', 'spades'),
+        ]),
+        mkCombination('group', [createCard('K', 'clubs'), createCard('K', 'diamonds'), createCard('K', 'spades')]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 6 — sequence of 7, same suit', () => {
+    const mission = findMission(6);
+
+    it('returns true for a 7-long sequence in one suit', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'hearts'),
+          createCard('2', 'hearts'),
+          createCard('3', 'hearts'),
+          createCard('4', 'hearts'),
+          createCard('5', 'hearts'),
+          createCard('6', 'hearts'),
+          createCard('7', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('returns false when the sequence is 6 long', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'hearts'),
+          createCard('2', 'hearts'),
+          createCard('3', 'hearts'),
+          createCard('4', 'hearts'),
+          createCard('5', 'hearts'),
+          createCard('6', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 7 — 7 cards same suit', () => {
+    const mission = findMission(7);
+
+    it('returns true when at least 7 normal cards share a suit across combinations', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'hearts'),
+          createCard('2', 'hearts'),
+          createCard('3', 'hearts'),
+          createCard('4', 'hearts'),
+        ]),
+        mkCombination('group', [
+          createCard('5', 'hearts'),
+          createCard('5', 'diamonds'),
+          createCard('5', 'spades'),
+        ]),
+        mkCombination('sequence', [
+          createCard('6', 'hearts'),
+          createCard('7', 'hearts'),
+          createCard('8', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+  });
+
+  describe('Mission 12 — free choice', () => {
+    const mission = findMission(12);
+
+    it('completes if any prior mission was already done', () => {
+      expect(isMissionCompleted(mkPlayer([], [3]), mission)).toBe(true);
+    });
+    it('does not complete if no missions have been done', () => {
+      expect(isMissionCompleted(mkPlayer([], []), mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 13 — group of 4 + sequence of 4', () => {
+    const mission = findMission(13);
+
+    it('returns true with both', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('K', 'clubs'),
+          createCard('K', 'diamonds'),
+          createCard('K', 'spades'),
+          createCard('K', 'hearts'),
+        ]),
+        mkCombination('sequence', [
+          createCard('4', 'spades'),
+          createCard('5', 'spades'),
+          createCard('6', 'spades'),
+          createCard('7', 'spades'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('returns false when group is only 3', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('K', 'clubs'),
+          createCard('K', 'diamonds'),
+          createCard('K', 'spades'),
+        ]),
+        mkCombination('sequence', [
+          createCard('4', 'spades'),
+          createCard('5', 'spades'),
+          createCard('6', 'spades'),
+          createCard('7', 'spades'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 14 — two groups of 4', () => {
+    const mission = findMission(14);
+
+    it('passes with two groups of 4', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('K', 'clubs'),
+          createCard('K', 'diamonds'),
+          createCard('K', 'spades'),
+          createCard('K', 'hearts'),
+        ]),
+        mkCombination('group', [
+          createCard('7', 'clubs'),
+          createCard('7', 'diamonds'),
+          createCard('7', 'spades'),
+          createCard('7', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('fails when one group has only 3 cards', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('K', 'clubs'),
+          createCard('K', 'diamonds'),
+          createCard('K', 'spades'),
+          createCard('K', 'hearts'),
+        ]),
+        mkCombination('group', [
+          createCard('7', 'clubs'),
+          createCard('7', 'diamonds'),
+          createCard('7', 'spades'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 16 — sequence of 8 with at most 2 suits', () => {
+    const mission = findMission(16);
+
+    it('passes with an 8-long sequence in one suit', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'hearts'),
+          createCard('2', 'hearts'),
+          createCard('3', 'hearts'),
+          createCard('4', 'hearts'),
+          createCard('5', 'hearts'),
+          createCard('6', 'hearts'),
+          createCard('7', 'hearts'),
+          createCard('8', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('fails when sequence cards span 3 suits', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'hearts'),
+          createCard('2', 'hearts'),
+          createCard('3', 'diamonds'),
+          createCard('4', 'diamonds'),
+          createCard('5', 'spades'),
+          createCard('6', 'spades'),
+          createCard('7', 'spades'),
+          createCard('8', 'spades'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 21 — two sequences of 5, different suits', () => {
+    const mission = findMission(21);
+
+    it('passes with two same-length seqs in different suits', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'hearts'),
+          createCard('2', 'hearts'),
+          createCard('3', 'hearts'),
+          createCard('4', 'hearts'),
+          createCard('5', 'hearts'),
+        ]),
+        mkCombination('sequence', [
+          createCard('A', 'spades'),
+          createCard('2', 'spades'),
+          createCard('3', 'spades'),
+          createCard('4', 'spades'),
+          createCard('5', 'spades'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('fails when both sequences share a suit', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'hearts'),
+          createCard('2', 'hearts'),
+          createCard('3', 'hearts'),
+          createCard('4', 'hearts'),
+          createCard('5', 'hearts'),
+        ]),
+        mkCombination('sequence', [
+          createCard('6', 'hearts'),
+          createCard('7', 'hearts'),
+          createCard('8', 'hearts'),
+          createCard('9', 'hearts'),
+          createCard('10', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 24 — full suit A to K', () => {
+    const mission = findMission(24);
+
+    it('passes with 13-card sequence in one suit', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('A', 'spades'),
+          createCard('2', 'spades'),
+          createCard('3', 'spades'),
+          createCard('4', 'spades'),
+          createCard('5', 'spades'),
+          createCard('6', 'spades'),
+          createCard('7', 'spades'),
+          createCard('8', 'spades'),
+          createCard('9', 'spades'),
+          createCard('10', 'spades'),
+          createCard('J', 'spades'),
+          createCard('Q', 'spades'),
+          createCard('K', 'spades'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+  });
+
+  describe('Mission 28 — one red group + one black group', () => {
+    const mission = findMission(28);
+
+    it('passes with red and black groups', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('5', 'hearts'),
+          createCard('5', 'diamonds'),
+          createJokerCard(),
+        ]),
+        mkCombination('group', [
+          createCard('K', 'spades'),
+          createCard('K', 'clubs'),
+          createJokerCard(),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('fails when both groups are red', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('5', 'hearts'),
+          createCard('5', 'diamonds'),
+          createJokerCard(),
+        ]),
+        mkCombination('group', [
+          createCard('K', 'hearts'),
+          createCard('K', 'diamonds'),
+          createJokerCard(),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 29 — three suits, no diamonds', () => {
+    const mission = findMission(29);
+
+    it('passes when group has spades + clubs + hearts and no diamonds', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('5', 'spades'),
+          createCard('5', 'clubs'),
+          createCard('5', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('fails when group includes diamonds', () => {
+      const player = mkPlayer([
+        mkCombination('group', [
+          createCard('5', 'spades'),
+          createCard('5', 'clubs'),
+          createCard('5', 'hearts'),
+          createCard('5', 'diamonds'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+
+  describe('Mission 30 — red even sequence (2,4,6,8,10,Q)', () => {
+    const mission = findMission(30);
+
+    it('passes when all six even values are present in red cards', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('2', 'hearts'),
+          createCard('4', 'hearts'),
+          createCard('6', 'diamonds'),
+          createCard('8', 'diamonds'),
+          createCard('10', 'hearts'),
+          createCard('Q', 'diamonds'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(true);
+    });
+
+    it('fails when one even value is missing', () => {
+      const player = mkPlayer([
+        mkCombination('sequence', [
+          createCard('2', 'hearts'),
+          createCard('4', 'hearts'),
+          createCard('6', 'diamonds'),
+          createCard('8', 'diamonds'),
+          createCard('10', 'hearts'),
+        ]),
+      ]);
+      expect(isMissionCompleted(player, mission)).toBe(false);
+    });
+  });
+});

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -13,7 +13,6 @@ export type SpecificRequirement =
   | 'sequence_A_to_9'
   | 'seven_odd_cards'
   | 'different_suits'
-  | 'pairs'
   | 'three_groups_of_4'
   | 'full_suit_A_to_K'
   | 'hearts_7_8_9_10'

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -1,0 +1,166 @@
+import { Card, Combination, Mission, NormalCard, Player } from '../types/game';
+import { isJokerCard, isNormalCard, isValidGroup, isValidSequence } from './cardUtils';
+
+const isRedCard = (card: NormalCard) => card.suit === 'hearts' || card.suit === 'diamonds';
+const isBlackCard = (card: NormalCard) => card.suit === 'spades' || card.suit === 'clubs';
+
+export const isMissionCompleted = (
+  player: Pick<Player, 'combinations' | 'completedMissions'>,
+  mission: Mission
+): boolean => {
+  const { requirements } = mission;
+  const { combinations } = player;
+
+  const allCards = (): Card[] => combinations.flatMap(c => c.cards);
+  const groups = (): Combination[] => combinations.filter(c => c.type === 'group');
+  const sequences = (): Combination[] => combinations.filter(c => c.type === 'sequence');
+
+  switch (requirements.specificRequirements) {
+    case 'free_choice':
+      return player.completedMissions.length > 0;
+
+    case '7_same_suit': {
+      const suitCounts = combinations.reduce((acc, combo) => {
+        combo.cards.forEach(card => {
+          if (isNormalCard(card)) {
+            acc[card.suit] = (acc[card.suit] || 0) + 1;
+          }
+        });
+        return acc;
+      }, {} as Record<string, number>);
+      return Object.values(suitCounts).some(count => count >= 7);
+    }
+
+    case 'group_4_sequence_4':
+      return groups().some(g => g.cards.length === 4) &&
+             sequences().some(s => s.cards.length >= 4);
+
+    case 'groups_of_4':
+      return groups().filter(g => g.cards.length === 4).length >= 2;
+
+    case 'sequence_8_max_2_suits':
+      return sequences().some(seq => {
+        if (seq.cards.length < 8) return false;
+        const suits = new Set(seq.cards.filter(isNormalCard).map(c => c.suit));
+        return suits.size <= 2;
+      });
+
+    case 'two_groups_3_one_group_4': {
+      const gs = groups();
+      const of3 = gs.filter(g => g.cards.length === 3).length;
+      const of4 = gs.filter(g => g.cards.length === 4).length;
+      return of3 >= 2 && of4 >= 1;
+    }
+
+    case 'sequence_A_to_9': {
+      const normals = allCards().filter(isNormalCard);
+      const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9'];
+      return values.every(v => normals.some(c => c.value === v)) && normals.length >= 9;
+    }
+
+    case 'seven_odd_cards': {
+      const oddValues = ['A', '3', '5', '7', '9', 'J', 'K'];
+      return allCards().filter(isNormalCard).filter(c => oddValues.includes(c.value)).length >= 7;
+    }
+
+    case 'different_suits': {
+      const seqs = sequences().filter(s => s.cards.length >= 5);
+      if (seqs.length < 2) return false;
+      const suits1 = new Set(seqs[0].cards.filter(isNormalCard).map(c => c.suit));
+      const suits2 = new Set(seqs[1].cards.filter(isNormalCard).map(c => c.suit));
+      return [...suits1].every(s => !suits2.has(s));
+    }
+
+    case 'three_groups_of_4':
+      return groups().filter(g => g.cards.length === 4).length >= 3;
+
+    case 'full_suit_A_to_K':
+      return sequences().some(seq => {
+        if (seq.cards.length < 13) return false;
+        const normals = seq.cards.filter(isNormalCard);
+        return new Set(normals.map(c => c.suit)).size === 1;
+      });
+
+    case 'hearts_7_8_9_10': {
+      const hearts = allCards().filter(isNormalCard).filter(c => c.suit === 'hearts');
+      return ['7', '8', '9', '10'].every(v => hearts.some(c => c.value === v));
+    }
+
+    case 'spades_and_clubs_sequences': {
+      const seqs = sequences().filter(s => s.cards.length >= 4);
+      const hasSpades = seqs.some(s => s.cards.filter(isNormalCard).every(c => c.suit === 'spades'));
+      const hasClubs = seqs.some(s => s.cards.filter(isNormalCard).every(c => c.suit === 'clubs'));
+      return hasSpades && hasClubs;
+    }
+
+    case 'red_sequence_5':
+      return sequences().some(seq => {
+        if (seq.cards.length < 5) return false;
+        const normals = seq.cards.filter(isNormalCard);
+        return normals.length >= 5 && normals.every(isRedCard);
+      });
+
+    case 'one_red_group_one_black_group': {
+      const gs = groups().filter(g => g.cards.length >= 3);
+      const hasRed = gs.some(g => g.cards.filter(isNormalCard).every(isRedCard));
+      const hasBlack = gs.some(g => g.cards.filter(isNormalCard).every(isBlackCard));
+      return hasRed && hasBlack;
+    }
+
+    case 'three_suits_no_diamonds':
+      return groups().some(g => {
+        if (g.cards.length < 3) return false;
+        const suits = new Set(g.cards.filter(isNormalCard).map(c => c.suit));
+        return suits.has('spades') && suits.has('clubs') && suits.has('hearts') && !suits.has('diamonds');
+      });
+
+    case 'red_even_sequence_6': {
+      const reds = allCards().filter(isNormalCard).filter(isRedCard);
+      return ['2', '4', '6', '8', '10', 'Q'].every(v => reds.some(c => c.value === v));
+    }
+
+    case 'same_suit': {
+      const minLen = requirements.minSequenceLength || 3;
+      const hasGroups = !requirements.groups || groups().length >= requirements.groups;
+      const hasSeqs = !requirements.sequences || sequences().length >= requirements.sequences;
+      const hasMinLen = !requirements.minSequenceLength ||
+        sequences().some(s => s.cards.length >= requirements.minSequenceLength!);
+      const hasSameSuit = sequences().some(seq => {
+        const normals = seq.cards.filter(isNormalCard);
+        return normals.length >= minLen && normals.every(c => c.suit === normals[0].suit);
+      });
+      return hasGroups && hasSeqs && hasMinLen && hasSameSuit;
+    }
+
+    default: {
+      const hasGroups = !requirements.groups || groups().length >= requirements.groups;
+      const hasSeqs = !requirements.sequences || sequences().length >= requirements.sequences;
+      const hasMinLen = !requirements.minSequenceLength ||
+        sequences().some(s => s.cards.length >= requirements.minSequenceLength!);
+      return hasGroups && hasSeqs && hasMinLen;
+    }
+  }
+};
+
+export const canAddToExistingCombination = (
+  cardsToAdd: Card[],
+  combination: Combination
+): boolean => {
+  const combined = [...combination.cards, ...cardsToAdd];
+  if (combination.type === 'group') return isValidGroup(combined);
+  if (combination.type === 'sequence') return isValidSequence(combined);
+  return false;
+};
+
+export const pickRandomMissionId = (
+  allMissions: Mission[],
+  completedMissions: number[],
+  rng: () => number = Math.random
+): number => {
+  const available = allMissions.filter(m => !completedMissions.includes(m.id));
+  if (available.length === 0) return allMissions[0]?.id ?? 1;
+  return available[Math.floor(rng() * available.length)].id;
+};
+
+// Re-export for callers who only need the joker check via this module
+export { isJokerCard };


### PR DESCRIPTION
## Summary
- Extract pure rules engine (mission completion, combination extension, mission picker) from `useGameState` into `src/utils/gameLogic.ts` so it can be unit-tested without React.
- Fix a validation bug in `canAddToExistingCombination`: it accepted adding a duplicate-suit card to an existing group because it only matched values; now revalidates via `isValidGroup` / `isValidSequence`.
- Clean up dead code: remove the `pairs` `SpecificRequirement` (no mission uses it and `isValidGroup` requires ≥3 cards anyway) and the duplicated `getSuitSymbol`.
- Bring `aiPlayer.ts` from 0% to 100% coverage and add 35 tests for the new `gameLogic.ts` module. Total tests: 288 → 336.

## Test plan
- [x] `pnpm test` — 336 passing
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — no new warnings (only pre-existing shadcn UI warnings)
- [ ] Manual smoke check that mission completion still triggers and combinations can be extended in the running game

🤖 Generated with [Claude Code](https://claude.com/claude-code)